### PR TITLE
Fix markdowns

### DIFF
--- a/src/crackers/README.md
+++ b/src/crackers/README.md
@@ -1,1 +1,1 @@
-Please read [mod.rs][mod.rs] for the latest up to date documentation.
+Please read [mod.rs](mod.rs) for the latest up to date documentation.

--- a/src/decoders/README.md
+++ b/src/decoders/README.md
@@ -1,3 +1,3 @@
-Please read [mod.rs][mod.rs] for the latest up to date documentation.
+Please read [mod.rs](mod.rs) for the latest up to date documentation.
 
 The `interface.rs` defines what each decoder looks like.


### PR DESCRIPTION
Fixed [a][b] instead of [a](b) typos in 2 README.mds